### PR TITLE
support terminal width detection

### DIFF
--- a/interact/interaction.go
+++ b/interact/interaction.go
@@ -67,7 +67,12 @@ func (interaction Interaction) Resolve(dst interface{}) error {
 
 		defer terminal.Restore(int(file.Fd()), state)
 
-		user = newTTYUser(interaction.Input, interaction.Output)
+		term := newTTYUser(interaction.Input, interaction.Output)
+		err = term.detectTerminalSize(file)
+		if err != nil {
+			return err
+		}
+		user = term
 	} else {
 		user = newNonTTYUser(interaction.Input, interaction.Output)
 	}

--- a/interact/interaction.go
+++ b/interact/interaction.go
@@ -67,11 +67,11 @@ func (interaction Interaction) Resolve(dst interface{}) error {
 
 		defer terminal.Restore(int(file.Fd()), state)
 
-		term := newTTYUser(interaction.Input, interaction.Output)
-		err = term.detectTerminalSize(file)
+		term, err := newTTYUser(file, interaction.Output)
 		if err != nil {
 			return err
 		}
+
 		user = term
 	} else {
 		user = newNonTTYUser(interaction.Input, interaction.Output)

--- a/interact/terminal/terminal.go
+++ b/interact/terminal/terminal.go
@@ -6,10 +6,13 @@ package terminal
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sync"
 	"unicode/utf8"
 )
+
+var ErrKeyboardInterrupt = errors.New("interrupt")
 
 // EscapeCodes contains escape sequences that can be written to the terminal in
 // order to achieve different styles of text.
@@ -111,6 +114,7 @@ func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
 }
 
 const (
+	keyCtrlC     = 3
 	keyCtrlD     = 4
 	keyCtrlU     = 21
 	keyEnter     = '\r'
@@ -717,6 +721,9 @@ func (t *Terminal) readLine() (line string, err error) {
 				break
 			}
 			if !t.pasteActive {
+				if key == keyCtrlC {
+					return "", ErrKeyboardInterrupt
+				}
 				if key == keyCtrlD {
 					if len(t.line) == 0 {
 						return "", io.EOF

--- a/interact/terminal/terminal_test.go
+++ b/interact/terminal/terminal_test.go
@@ -270,6 +270,50 @@ func TestTerminalSetSize(t *testing.T) {
 	}
 }
 
+func TestReadPasswordLineEnd(t *testing.T) {
+	var tests = []struct {
+		input string
+		want  string
+	}{
+		{"\n", ""},
+		{"\r\n", ""},
+		{"test\r\n", "test"},
+		{"testtesttesttes\n", "testtesttesttes"},
+		{"testtesttesttes\r\n", "testtesttesttes"},
+		{"testtesttesttesttest\n", "testtesttesttesttest"},
+		{"testtesttesttesttest\r\n", "testtesttesttesttest"},
+	}
+	for _, test := range tests {
+		buf := new(bytes.Buffer)
+		if _, err := buf.WriteString(test.input); err != nil {
+			t.Fatal(err)
+		}
+
+		have, err := readPasswordLine(buf)
+		if err != nil {
+			t.Errorf("readPasswordLine(%q) failed: %v", test.input, err)
+			continue
+		}
+		if string(have) != test.want {
+			t.Errorf("readPasswordLine(%q) returns %q, but %q is expected", test.input, string(have), test.want)
+			continue
+		}
+
+		if _, err = buf.WriteString(test.input); err != nil {
+			t.Fatal(err)
+		}
+		have, err = readPasswordLine(buf)
+		if err != nil {
+			t.Errorf("readPasswordLine(%q) failed: %v", test.input, err)
+			continue
+		}
+		if string(have) != test.want {
+			t.Errorf("readPasswordLine(%q) returns %q, but %q is expected", test.input, string(have), test.want)
+			continue
+		}
+	}
+}
+
 func TestMakeRawState(t *testing.T) {
 	fd := int(os.Stdout.Fd())
 	if !IsTerminal(fd) {

--- a/interact/terminal/util.go
+++ b/interact/terminal/util.go
@@ -14,10 +14,9 @@
 // 	        panic(err)
 // 	}
 // 	defer terminal.Restore(0, oldState)
-package terminal
+package terminal // import "golang.org/x/crypto/ssh/terminal"
 
 import (
-	"io"
 	"syscall"
 	"unsafe"
 )
@@ -72,8 +71,10 @@ func GetState(fd int) (*State, error) {
 // Restore restores the terminal connected to the given file descriptor to a
 // previous state.
 func Restore(fd int, state *State) error {
-	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0)
-	return err
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0); err != 0 {
+		return err
+	}
+	return nil
 }
 
 // GetSize returns the dimensions of the given terminal.
@@ -84,6 +85,13 @@ func GetSize(fd int) (width, height int, err error) {
 		return -1, -1, err
 	}
 	return int(dimensions[1]), int(dimensions[0]), nil
+}
+
+// passwordReader is an io.Reader that reads from a specific file descriptor.
+type passwordReader int
+
+func (r passwordReader) Read(buf []byte) (int, error) {
+	return syscall.Read(int(r), buf)
 }
 
 // ReadPassword reads a line of input from a terminal without local echo.  This
@@ -107,27 +115,5 @@ func ReadPassword(fd int) ([]byte, error) {
 		syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0)
 	}()
 
-	var buf [16]byte
-	var ret []byte
-	for {
-		n, err := syscall.Read(fd, buf[:])
-		if err != nil {
-			return nil, err
-		}
-		if n == 0 {
-			if len(ret) == 0 {
-				return nil, io.EOF
-			}
-			break
-		}
-		if buf[n-1] == '\n' {
-			n--
-		}
-		ret = append(ret, buf[:n]...)
-		if n < len(buf) {
-			break
-		}
-	}
-
-	return ret, nil
+	return readPasswordLine(passwordReader(fd))
 }

--- a/interact/terminal/util.go
+++ b/interact/terminal/util.go
@@ -14,7 +14,7 @@
 // 	        panic(err)
 // 	}
 // 	defer terminal.Restore(0, oldState)
-package terminal // import "golang.org/x/crypto/ssh/terminal"
+package terminal
 
 import (
 	"syscall"

--- a/interact/terminal/util_windows.go
+++ b/interact/terminal/util_windows.go
@@ -17,7 +17,6 @@
 package terminal
 
 import (
-	"io"
 	"syscall"
 	"unsafe"
 )
@@ -123,6 +122,13 @@ func GetSize(fd int) (width, height int, err error) {
 	return int(info.size.x), int(info.size.y), nil
 }
 
+// passwordReader is an io.Reader that reads from a specific Windows HANDLE.
+type passwordReader int
+
+func (r passwordReader) Read(buf []byte) (int, error) {
+	return syscall.Read(syscall.Handle(r), buf)
+}
+
 // ReadPassword reads a line of input from a terminal without local echo.  This
 // is commonly used for inputting passwords and other sensitive data. The slice
 // returned does not include the \n.
@@ -145,30 +151,5 @@ func ReadPassword(fd int) ([]byte, error) {
 		syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(old), 0)
 	}()
 
-	var buf [16]byte
-	var ret []byte
-	for {
-		n, err := syscall.Read(syscall.Handle(fd), buf[:])
-		if err != nil {
-			return nil, err
-		}
-		if n == 0 {
-			if len(ret) == 0 {
-				return nil, io.EOF
-			}
-			break
-		}
-		if buf[n-1] == '\n' {
-			n--
-		}
-		if n > 0 && buf[n-1] == '\r' {
-			n--
-		}
-		ret = append(ret, buf[:n]...)
-		if n < len(buf) {
-			break
-		}
-	}
-
-	return ret, nil
+	return readPasswordLine(passwordReader(fd))
 }

--- a/interact/userio.go
+++ b/interact/userio.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/vito/go-interact/interact/terminal"
 )
@@ -25,6 +26,14 @@ func newTTYUser(input io.Reader, output io.Writer) ttyUser {
 	return ttyUser{
 		Terminal: terminal.NewTerminal(readWriter{input, output}, ""),
 	}
+}
+
+func (u ttyUser) detectTerminalSize(file *os.File) error {
+	width, height, err := terminal.GetSize(int(file.Fd()))
+	if err != nil {
+		return err
+	}
+	return u.SetSize(width, height)
 }
 
 func (u ttyUser) WriteLine(line string) error {


### PR DESCRIPTION
- Updated `ssh/terminal`
- Repatched `Ctrl`+`C` functionality
- Added auto width detection because always cutting the message off at 80 characters was weird. This fixes it in TTY sessions only.