### PR TITLE
ignore carriage return (CR) for non-TTY user input

### DIFF
--- a/interact/userio.go
+++ b/interact/userio.go
@@ -120,6 +120,8 @@ func (u nonTTYUser) readLine() (string, error) {
 		if n == 1 {
 			if chr[0] == '\n' {
 				return line, nil
+			} else if chr[0] == '\r' {
+				continue
 			}
 
 			line += string(chr)

--- a/interact/userio_test.go
+++ b/interact/userio_test.go
@@ -1,6 +1,9 @@
 package interact_test
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/kr/pty"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +33,39 @@ var _ = Describe("User IO", func() {
 				err = interaction.Resolve(&thing)
 
 				Expect(err).To(Equal(interact.ErrKeyboardInterrupt))
+			})
+		})
+	})
+
+	Describe("fetching input from a non-TTY user", func() {
+		Context("when passed a CRLF", func() {
+			var input, output *os.File
+
+			BeforeEach(func() {
+				var err error
+				input, err = ioutil.TempFile("", "go-interact-input")
+				Expect(err).ToNot(HaveOccurred())
+				err = ioutil.WriteFile(input.Name(), []byte("What do you mean? An African or European swallow?\r\n"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				output, err = ioutil.TempFile("", "go-interact-output")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(os.RemoveAll(input.Name())).ToNot(HaveOccurred())
+				Expect(os.RemoveAll(output.Name())).ToNot(HaveOccurred())
+			})
+
+			It("ignores the CR", func() {
+				interaction := interact.NewInteraction("What is the air-speed of a Swallow?")
+				interaction.Input = input
+				interaction.Output = output
+
+				var thing string
+				err := interaction.Resolve(&thing)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(thing).To(Equal("What do you mean? An African or European swallow?"))
 			})
 		})
 	})


### PR DESCRIPTION
This fix is primarily for windows. It seems that it has `echo` in powershell/cmd.exe now, and using it in a script to pass values to go-interact doesn't work due to the `\r`.

I took a cue from [teriminal#readPasswordLine](https://github.com/vito/go-interact/blob/master/interact/terminal/terminal.go#L944-L945) and ignored the carriage return whenever it is read.