### PR TITLE
input's FD works on windows now

### DIFF
--- a/interact/interaction.go
+++ b/interact/interaction.go
@@ -59,7 +59,7 @@ func (interaction Interaction) Resolve(dst interface{}) error {
 	prompt := interaction.prompt(dst)
 
 	var user userIO
-	if input, output, ok := interaction.getStreams(); ok && terminal.IsTerminal(int(output.Fd())) {
+	if input, output, ok := interaction.getStreams(); ok && terminal.IsTerminal(int(input.Fd())) {
 		state, err := terminal.MakeRaw(int(input.Fd()))
 		if err != nil {
 			return err


### PR DESCRIPTION
This also fixes issues when STDIN is not a TTY (ie from a file, pipe'd in, etc.).