### PR TITLE
Changed check isTerminal to use output stream file descriptor

### DIFF
--- a/example/test-pipe
+++ b/example/test-pipe
@@ -1,0 +1,67 @@
+#!/usr/bin/expect -f
+
+set timeout 1
+
+spawn sh -c { go run main.go | tee /dev/null }
+
+expect -ex {Well? [yN]} {} timeout { exit 1 }
+send "\r"
+expect "\r\nfalse\r\n" {} timeout { exit 1 }
+
+expect -ex {Well? [Yn]: } {} timeout { exit 1 }
+send "\r"
+expect "\r\ntrue\r\n" {} timeout { exit 1 }
+
+expect -ex {Well? [yn]: } {} timeout { exit 1 }
+send "y\r"
+expect "\r\ntrue\r\n" {} timeout { exit 1 }
+
+expect -ex {Message (hello): } {} timeout { exit 1 }
+send "\r"
+expect "\r\nhello\r\n" {} timeout { exit 1 }
+
+expect -ex {Message (): } {} timeout { exit 1 }
+send "\r"
+expect "\r\n\r\n" {} timeout { exit 1 }
+
+expect -ex {Message: } {} timeout { exit 1 }
+send "sup\r"
+expect "\r\nsup\r\n" {} timeout { exit 1 }
+
+expect -ex {1: One} {} timeout { exit 1 }
+expect -ex {2: Two} {} timeout { exit 1 }
+expect -ex {3: Three} {} timeout { exit 1 }
+expect -ex {Choose a number: } {} timeout { exit 1 }
+send "2\r"
+expect "\r\ndos\r\n" {} timeout { exit 1 }
+
+expect -ex {1: One} {} timeout { exit 1 }
+expect -ex {2: Two} {} timeout { exit 1 }
+expect -ex {3: Three} {} timeout { exit 1 }
+expect -ex {Choose a number (2): } {} timeout { exit 1 }
+send "\r"
+expect "\r\ndos\r\n" {} timeout { exit 1 }
+
+expect -ex {1: One} {} timeout { exit 1 }
+expect -ex {2: Two} {} timeout { exit 1 }
+expect -ex {3: Three} {} timeout { exit 1 }
+expect -ex {4: none} {} timeout { exit 1 }
+expect -ex {Choose a number (4): } {} timeout { exit 1 }
+send "\r"
+expect "\r\n<nil>\r\n" {} timeout { exit 1 }
+
+expect -ex {Username:} {} timeout { exit 1 }
+send "\r"
+expect "\r\nUsername: " {} timeout { exit 1 }
+send "bilbo\r"
+expect "\r\nbilbo\r\n" {} timeout { exit 1 }
+
+expect -ex {Password:} {} timeout { exit 1 }
+send "\r"
+expect "\r\nPassword: " {} timeout { exit 1 }
+send "baggins\r"
+expect "\r\nbaggins\r\n" {} timeout { exit 1 }
+
+expect -ex {Interrupt:} {} timeout { exit 1 }
+send \003
+expect "keyboard interrupt" {} timeout { exit 1 }

--- a/interact/interaction.go
+++ b/interact/interaction.go
@@ -59,7 +59,7 @@ func (interaction Interaction) Resolve(dst interface{}) error {
 	prompt := interaction.prompt(dst)
 
 	var user userIO
-	if input, output, ok := interaction.getStreams(); ok && terminal.IsTerminal(int(input.Fd())) {
+	if input, output, ok := interaction.getStreams(); ok && terminal.IsTerminal(int(output.Fd())) {
 		state, err := terminal.MakeRaw(int(input.Fd()))
 		if err != nil {
 			return err


### PR DESCRIPTION
- previously used input stream file descriptor

As [this example](https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go) suggests, one should test the file descriptor of the _output_ stream instead of the _input_ stream.

The following snippet is taken from above link:
```
   if terminal.IsTerminal(int(os.Stdout.Fd())) {
        fmt.Println("Hello terminal")
    } else {
        fmt.Println("Who are you?  You're not a terminal.")
    }
```
This is a fix for [https://github.com/vito/go-interact/issues/11](https://github.com/vito/go-interact/issues/11).

@vito could you review this, please?
